### PR TITLE
Add frontend to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,7 @@ services:
     networks:
       - default
       - reverse_proxy
+
   api-docs:
     build:
       context: ./api-docs
@@ -183,6 +184,22 @@ services:
       traefik.http.routers.dust_api_docs.middlewares: dust_api_docs-addslash, dust_api_docs-stripprefix
       traefik.http.services.dust_api_docs.loadbalancer.server.port: 80
       traefik.docker.network: reverse_proxy
+
+  public-frontend:
+    image: ghcr.io/vives-dust/frontend/dust-public-frontend:latest
+    ports:
+      - "80:80"
+    depends_on:
+      - backend
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.dust_public_frontend.rule: Host(`${APPLICATION_DOMAIN_NAME}`)
+      traefik.http.services.dust_public_frontend.loadbalancer.server.port: 80
+      traefik.docker.network: reverse_proxy
+    restart: unless-stopped
+    networks:
+      - default
+      - reverse_proxy
  
 volumes:
   influxdb2-data:


### PR DESCRIPTION
Add container to the docker compose for the public frontend. Frontend is being build using github action. So no need for local build.