### PR TITLE
Incorperating SapFlow sensors

### DIFF
--- a/process/src/InfluxDbClient.ts
+++ b/process/src/InfluxDbClient.ts
@@ -17,25 +17,7 @@ export default class InfluxDbClient {
     this.influxdb = new InfluxDB( { url: `http://${host}:${port}`, token}).getWriteApi(org, bucket, 'ms')
   }
 
-  public save( data: any) {
-    console.log('data', data)
-
-    const point = new Point("dust-sensor")
-      .tag( "codingRate", data.codingRate )
-      .tag( "devId", data.dev_id )
-      .tag( "hardwareSerial", data.hardwareSerial )
-      .timestamp( Date.parse(data.time))
-      .intField( "frequency", data.frequency)
-      .intField( "moistureLevel_1", data.moistureLevel_1)
-      .intField( "moistureLevel_2", data.moistureLevel_2)
-      .intField( "moistureLevel_3", data.moistureLevel_3)
-      .intField( "moistureLevel_4", data.moistureLevel_4)
-      .floatField( "battery", data.battery)
-      .floatField( "internalTemperature", data.internalTemperature)
-      .floatField( "rssi", data.rssi)
-      .floatField( "snr", data.snr)
-      .intField( "counter", data.counter)
-      .intField( "gateways", data.gateways)
+  public save( point :Point) {
     this.influxdb.writePoint(point)
     console.log(point)
 

--- a/process/src/app.ts
+++ b/process/src/app.ts
@@ -1,13 +1,27 @@
 import Redis from './RedisClient'
 import InfluxDB from './InfluxDbClient'
-import processDustData from './interfaces/dust-v3.interface';
-import processISFData from './interfaces/sapflow-isf.interface';
+import processDustData, { saveDustData } from './interfaces/dust-v3.interface';
+import processISFData, { saveISFData } from './interfaces/sapflow-isf.interface';
+
+interface dataProcessing {
+    process: Function,
+    save: Function
+
+}
+
+const deviceFPortMap: { [key: number] : dataProcessing } = {
+    // FPort for each type of sensordevice
+    1: {    process: processDustData,
+            save: saveDustData },
+    10: {   process: processISFData,
+            save: saveISFData },
+}
 
 const redis = new Redis({
     host: process.env.REDIS_HOST,
     port: process.env.REDIS_PORT ? parseInt(<string>process.env.REDIS_PORT) : undefined,
     key: process.env.REDIS_KEY
-})
+});
 
 const influxdb = new InfluxDB({
     host: process.env.INFLUXDB_HOST,
@@ -19,32 +33,23 @@ const influxdb = new InfluxDB({
 
 // console.log('Processing ready...')
 let stop = false;
-let data = {};
 
 ( async () => {
     while(!stop){
-        const input = JSON.parse((await redis.pull())[1])
-        if( input !== null){
-            try{
-                // Check which FPort is used on TTN
-                switch (input.uplink_message.f_port){
-                    case 1:
-                        // FPort = 1 are the DUST v3 Soil Moisture Sensors
-                        data = processDustData(input);
-                        break;
-                    case 10:
-                        // FPort = 10 are the Decentlab SapFlow Sensors
-                        data = processISFData(input);
-                        break;
-                    default:
-                        console.error('Data was sent through non-assigned FPort', input);
-                        break;                    
-                }
-                influxdb.save(data)
-            } catch (error) {
-                console.error('Input has wrong format', input)
-                console.error(error)
-            }
+        const input = JSON.parse((await redis.pull())[1] || "{}")
+        if( Object.keys(input).length === 0) { break }
+        const fport = input.uplink_message.f_port
+        if( !(fport in deviceFPortMap)) {
+            console.error('Data was sent through non-assigned FPort', input)
+            break
+        }
+        try {
+            // Process the input, create a point for saving in influx and save the point for each specific sensordevice
+            const point = deviceFPortMap[fport].save(deviceFPortMap[fport].process(input))
+            influxdb.save(point)
+        } catch (error) {
+            console.error('Input has wrong format', input)
+            console.error(error)
         }
     }
 })()

--- a/process/src/interfaces/dust-v3.interface.ts
+++ b/process/src/interfaces/dust-v3.interface.ts
@@ -1,0 +1,26 @@
+import processConnectionData from "./lorawan-conn.interface";
+
+interface DustV3SoilMoisture {
+  moistureLevel_1: number,
+  moistureLevel_2: number,
+  moistureLevel_3: number,
+  moistureLevel_4: number,
+  battery: number,
+  internalTemperature: number,
+  dev_id: string,
+  hardwareSerial: string,
+}
+
+export default function processDustData(input :any) :DustV3SoilMoisture {
+  return {
+      moistureLevel_1: input.uplink_message.decoded_payload.moistureLevel_1,
+      moistureLevel_2: input.uplink_message.decoded_payload.moistureLevel_2,
+      moistureLevel_3: input.uplink_message.decoded_payload.moistureLevel_3,
+      moistureLevel_4: input.uplink_message.decoded_payload.moistureLevel_4,
+      battery: input.uplink_message.decoded_payload.batteryVoltage,
+      internalTemperature: input.uplink_message.decoded_payload.internalTemperature,
+      dev_id: input.end_device_ids.device_id,
+      hardwareSerial: input.end_device_ids.dev_eui,
+      ...processConnectionData(input)
+  }
+}

--- a/process/src/interfaces/dust-v3.interface.ts
+++ b/process/src/interfaces/dust-v3.interface.ts
@@ -1,4 +1,5 @@
 import processConnectionData from "./lorawan-conn.interface";
+import { Point } from '@influxdata/influxdb-client'
 
 interface DustV3SoilMoisture {
   moistureLevel_1: number,
@@ -23,4 +24,25 @@ export default function processDustData(input :any) :DustV3SoilMoisture {
       hardwareSerial: input.end_device_ids.dev_eui,
       ...processConnectionData(input)
   }
+}
+
+export function saveDustData(data :any) {
+  const point = new Point("dust-sensor")
+      .tag( "codingRate", data.codingRate )
+      .tag( "devId", data.dev_id )
+      .tag( "hardwareSerial", data.hardwareSerial )
+      .timestamp( Date.parse(data.time))
+      .intField( "frequency", data.frequency)
+      .intField( "moistureLevel_1", data.moistureLevel_1)
+      .intField( "moistureLevel_2", data.moistureLevel_2)
+      .intField( "moistureLevel_3", data.moistureLevel_3)
+      .intField( "moistureLevel_4", data.moistureLevel_4)
+      .floatField( "battery", data.battery)
+      .floatField( "internalTemperature", data.internalTemperature)
+      .floatField( "rssi", data.rssi)
+      .floatField( "snr", data.snr)
+      .intField( "counter", data.counter)
+      .intField( "gateways", data.gateways)
+
+  return point
 }

--- a/process/src/interfaces/lorawan-conn.interface.ts
+++ b/process/src/interfaces/lorawan-conn.interface.ts
@@ -1,0 +1,35 @@
+interface LoRaWAN {
+  time: string,
+  frequency: number,
+  codingRate: string,
+  airtime: number,
+  rssi: number,
+  snr: number,
+  spreadFactor: number,
+  counter: number,
+  gateways: number,
+}
+
+export default function processConnectionData(input :any) :LoRaWAN {
+  return {
+      time: input.received_at,
+      frequency: input.uplink_message.settings.frequency,
+      codingRate: input.uplink_message.settings.coding_rate,
+      airtime: (input.uplink_message.consumed_airtime).replace('s', ''),
+      rssi: getBestRssi(input.uplink_message.rx_metadata),
+      snr: getBestSnr(input.uplink_message.rx_metadata),
+      spreadFactor: input.uplink_message.settings.data_rate.lora.spreading_factor,
+      counter: input.uplink_message.f_cnt,
+      gateways: input.uplink_message.rx_metadata.filter( (g :any) => g.gateway_id !== "packetbroker").length
+  }
+}
+
+function getBestRssi(gateways :any) :number{
+  const rssis = gateways.map( (gateway :any) => gateway.rssi)
+  return Math.max(...rssis)
+}
+
+function getBestSnr(gateways :any) :number{
+  const snrs = gateways.map( (gateway : any) => gateway.snr)
+  return Math.max(...snrs)
+}

--- a/process/src/interfaces/lorawan-conn.interface.ts
+++ b/process/src/interfaces/lorawan-conn.interface.ts
@@ -1,7 +1,7 @@
 interface LoRaWAN {
   time: string,
   frequency: number,
-  codingRate: string,
+  codingRate: number,
   airtime: number,
   rssi: number,
   snr: number,
@@ -14,7 +14,7 @@ export default function processConnectionData(input :any) :LoRaWAN {
   return {
       time: input.received_at,
       frequency: input.uplink_message.settings.frequency,
-      codingRate: input.uplink_message.settings.coding_rate,
+      codingRate: input.uplink_message.settings.data_rate.lora.coding_rate,
       airtime: (input.uplink_message.consumed_airtime).replace('s', ''),
       rssi: getBestRssi(input.uplink_message.rx_metadata),
       snr: getBestSnr(input.uplink_message.rx_metadata),

--- a/process/src/interfaces/sapflow-isf.interface.ts
+++ b/process/src/interfaces/sapflow-isf.interface.ts
@@ -1,20 +1,21 @@
 import processConnectionData from "./lorawan-conn.interface";
+import { Point } from '@influxdata/influxdb-client'
 
 interface SapFlowISF {
-  alpha_inner: number,
-  alpha_outer: number,
-  beta_inner: number,
-  beta_outer: number,
-  heat_velocity_inner: number,
-  heat_velocity_outer: number,
-  max_voltage: number,
-  min_voltage: number,
-  sap_flow: number,
-  temperature_outer: number,
-  tmax_inner: number,
-  tmax_outer: number,
-  upstream_tmax_inner: number,
-  upstream_tmax_outer: number,
+  alphaInner: number,
+  alphaOuter: number,
+  betaInner: number,
+  betaOuter: number,
+  heatVelocityInner: number,
+  heatVelocityOuter: number,
+  maxVoltage: number,
+  minVoltage: number,
+  sapFlow: number,
+  temperatureOuter: number,
+  tmaxInner: number,
+  tmaxOuter: number,
+  upstreamTmaxInner: number,
+  upstreamTmaxOuter: number,
   battery: number,
   device_id: string,
   protocol_version: number,
@@ -25,26 +26,59 @@ interface SapFlowISF {
 
 export default function processISFData(input :any) :SapFlowISF {
   return {
-      alpha_inner: input.uplink_message.decoded_payload.alpha_inner,
-      alpha_outer: input.uplink_message.decoded_payload.alpha_outer,
-      beta_inner: input.uplink_message.decoded_payload.beta_inner,
-      beta_outer: input.uplink_message.decoded_payload.beta_outer,
-      heat_velocity_inner: input.uplink_message.decoded_payload.heat_velocity_inner,
-      heat_velocity_outer: input.uplink_message.decoded_payload.heat_velocity_outer,
-      max_voltage: input.uplink_message.decoded_payload.max_voltage,
-      min_voltage: input.uplink_message.decoded_payload.min_voltage,
-      sap_flow: input.uplink_message.decoded_payload.sap_flow,
-      temperature_outer: input.uplink_message.decoded_payload.temperature_outer,
-      tmax_inner: input.uplink_message.decoded_payload.tmax_inner,
-      tmax_outer: input.uplink_message.decoded_payload.tmax_outer,
-      upstream_tmax_inner: input.uplink_message.decoded_payload.upstream_tmax_inner,
-      upstream_tmax_outer: input.uplink_message.decoded_payload.upstream_tmax_outer,
-      battery: input.uplink_message.decoded_payload.battery,
+      alphaInner: input.uplink_message.decoded_payload.alpha_inner.value,
+      alphaOuter: input.uplink_message.decoded_payload.alpha_outer.value,
+      betaInner: input.uplink_message.decoded_payload.beta_inner.value,
+      betaOuter: input.uplink_message.decoded_payload.beta_outer.value,
+      heatVelocityInner: input.uplink_message.decoded_payload.heat_velocity_inner.value,
+      heatVelocityOuter: input.uplink_message.decoded_payload.heat_velocity_outer.value,
+      maxVoltage: input.uplink_message.decoded_payload.max_voltage.value,
+      minVoltage: input.uplink_message.decoded_payload.min_voltage.value,
+      sapFlow: input.uplink_message.decoded_payload.sap_flow.value,
+      temperatureOuter: input.uplink_message.decoded_payload.temperature_outer.value,
+      tmaxInner: input.uplink_message.decoded_payload.tmax_inner.value,
+      tmaxOuter: input.uplink_message.decoded_payload.tmax_outer.value,
+      upstreamTmaxInner: input.uplink_message.decoded_payload.upstream_tmax_inner.value,
+      upstreamTmaxOuter: input.uplink_message.decoded_payload.upstream_tmax_outer.value,
+      battery: input.uplink_message.decoded_payload.battery_voltage.value,
       device_id: input.uplink_message.decoded_payload.device_id,
       protocol_version: input.uplink_message.decoded_payload.protocol_version,
-      diagnostic: input.uplink_message.decoded_payload.diagnostic,
+      diagnostic: input.uplink_message.decoded_payload.diagnostic.value,
       dev_id: input.end_device_ids.device_id,
       hardwareSerial: input.end_device_ids.dev_eui,
       ...processConnectionData(input)
   }
+}
+
+export function saveISFData(data :any) {
+  const point = new Point("sapflow-sensor")
+    .tag( "codingRate", data.codingRate )
+    .tag( "devId", data.dev_id )
+    .tag( "hardwareSerial", data.hardwareSerial )
+    .timestamp( Date.parse(data.time))
+    .intField( "frequency", data.frequency)
+    .floatField( "alphaInner", data.alphaInner)
+    .floatField( "alphaOuter", data.alphaOuter)
+    .floatField( "betaInner", data.betaInner)
+    .floatField( "betaOuter", data.betaOuter)
+    .floatField( "heatVelocityInner", data.heatVelocityInner)
+    .floatField( "heatVelocityOuter", data.heatVelocityOuter)
+    .floatField( "maxVoltage", data.maxVoltage)
+    .floatField( "minVoltage", data.minVoltage)
+    .floatField( "sapFlow", data.sapFlow)
+    .floatField( "temperatureOuter", data.temperatureOuter)
+    .floatField( "tmaxInner", data.tmaxInner)
+    .floatField( "tmaxOuter", data.tmaxOuter)
+    .floatField( "upstreamTmaxInner", data.upstreamTmaxInner)
+    .floatField( "upstreamTmaxOuter", data.upstreamTmaxOuter)
+    .floatField( "battery", data.battery)
+    .intField( "device_id", data.device_id)
+    .intField( "protocol_version", data.protocol_version)
+    .intField( "diagnostic", data.diagnostic)
+    .floatField( "rssi", data.rssi)
+    .floatField( "snr", data.snr)
+    .intField( "counter", data.counter)
+    .intField( "gateways", data.gateways)
+
+  return point
 }

--- a/process/src/interfaces/sapflow-isf.interface.ts
+++ b/process/src/interfaces/sapflow-isf.interface.ts
@@ -1,0 +1,50 @@
+import processConnectionData from "./lorawan-conn.interface";
+
+interface SapFlowISF {
+  alpha_inner: number,
+  alpha_outer: number,
+  beta_inner: number,
+  beta_outer: number,
+  heat_velocity_inner: number,
+  heat_velocity_outer: number,
+  max_voltage: number,
+  min_voltage: number,
+  sap_flow: number,
+  temperature_outer: number,
+  tmax_inner: number,
+  tmax_outer: number,
+  upstream_tmax_inner: number,
+  upstream_tmax_outer: number,
+  battery: number,
+  device_id: string,
+  protocol_version: number,
+  diagnostic: number,
+  dev_id: string,
+  hardwareSerial: string,
+}
+
+export default function processISFData(input :any) :SapFlowISF {
+  return {
+      alpha_inner: input.uplink_message.decoded_payload.alpha_inner,
+      alpha_outer: input.uplink_message.decoded_payload.alpha_outer,
+      beta_inner: input.uplink_message.decoded_payload.beta_inner,
+      beta_outer: input.uplink_message.decoded_payload.beta_outer,
+      heat_velocity_inner: input.uplink_message.decoded_payload.heat_velocity_inner,
+      heat_velocity_outer: input.uplink_message.decoded_payload.heat_velocity_outer,
+      max_voltage: input.uplink_message.decoded_payload.max_voltage,
+      min_voltage: input.uplink_message.decoded_payload.min_voltage,
+      sap_flow: input.uplink_message.decoded_payload.sap_flow,
+      temperature_outer: input.uplink_message.decoded_payload.temperature_outer,
+      tmax_inner: input.uplink_message.decoded_payload.tmax_inner,
+      tmax_outer: input.uplink_message.decoded_payload.tmax_outer,
+      upstream_tmax_inner: input.uplink_message.decoded_payload.upstream_tmax_inner,
+      upstream_tmax_outer: input.uplink_message.decoded_payload.upstream_tmax_outer,
+      battery: input.uplink_message.decoded_payload.battery,
+      device_id: input.uplink_message.decoded_payload.device_id,
+      protocol_version: input.uplink_message.decoded_payload.protocol_version,
+      diagnostic: input.uplink_message.decoded_payload.diagnostic,
+      dev_id: input.end_device_ids.device_id,
+      hardwareSerial: input.end_device_ids.dev_eui,
+      ...processConnectionData(input)
+  }
+}


### PR DESCRIPTION
Data flow from SapFlow sensors to influxDB:

- Changed **process** service to allow processing and saving of the data
- Added interfaces for each sensordevice

This closes #189.